### PR TITLE
Add post-install code to register the DLL in setup.py

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,16 +8,16 @@ The purpose of the project is to support ARIA and HTML5 implementation of the ac
 
 * Install python 2.7 and pip for Windows 
 * Clone this repository
-* Register IAccessible2Proxy.dll with Windows (Note: this needs to be done with administration priveleges)
-  
-```
-regsvr32 IAccessible2Proxy.dll
-```
-
 * Install using pip
   
 ```
 pip install -e C:\path\to\repository
+```
+
+* The `setup.py` file will try to register IAccessible2Proxy.dll with Windows. If it fails, then you need to register it manually with administration privileges:
+
+```
+regsvr32 IAccessible2Proxy.dll
 ```
 
 ## Examples

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,15 @@
 r"""A MSAA client library.
 
 """
+
+import ctypes
+import os
+import sys
+
 from setuptools import setup
 import pyia2
+from setuptools.command.develop import develop
+from setuptools.command.install import install
 
 classifiers = [
     'Development Status :: 3 - Alpha',
@@ -12,6 +19,41 @@ classifiers = [
     'Programming Language :: Python',
     'Topic :: Software Development :: Libraries :: Python Modules',
     ]
+
+
+def post_install():
+    # Display a message about registering the DLL.
+    print("Attempting to register IAccessible2Proxy.dll with elevated "
+          "privileges...")
+
+    # Do this via the Windows ShellExecuteA / ShellExecuteW functions.
+    # Use the ANSI function if using Python 2.
+    shell32 = ctypes.windll.shell32
+    PY2 = sys.version_info[0] == 2
+    ShellExecute = shell32.ShellExecuteA if PY2 else shell32.ShellExecuteW
+
+    # Get the DLL's path and attempt to register it with elevated privileges.
+    dll_path = os.path.join(os.getcwd(), "pyia2", "IAccessible2Proxy.dll")
+    return_code = ShellExecute(None, "runas", "regsvr32.exe", dll_path, None, 1)
+    if return_code > 32:
+        print("Success.")
+    else:
+        print("Failed to register the DLL. It must be registered manually.")
+
+
+class PostDevelopCommand(develop):
+    """Post-installation for development mode."""
+    def run(self):
+        post_install()
+        develop.run(self)
+
+
+class PostInstallCommand(install):
+    """Post-installation for installation mode."""
+    def run(self):
+        post_install()
+        install.run(self)
+
 
 setup(name="pyia2",
       description="Python MSAA+IAccessible2 client library",
@@ -25,4 +67,8 @@ setup(name="pyia2",
       version=pyia2.__version__,
       packages=["pyia2"],
       package_data={"": ["*.tlb"]},
-      install_requires=["comtypes"])
+      install_requires=["comtypes"],
+      cmdclass={
+          'develop': PostDevelopCommand,
+          'install': PostInstallCommand,
+      })


### PR DESCRIPTION
This uses the Windows `ShellExecute` function to register the `IAccessible2Proxy.dll` file with administrative privileges. The UAC prompt and regsrv32 success/failure dialog windows will be shown. I've also updated the installation instructions in the readme.

This makes `pyia2` slightly easier to install :-)

The package is still installed if the command fails for some reason.