### PR TITLE
Add support for Python 3

### DIFF
--- a/pyia2/__init__.py
+++ b/pyia2/__init__.py
@@ -29,10 +29,10 @@ from comtypes.client import GetModule
 GetModule('oleacc.dll')
 from comtypes.gen.Accessibility import IAccessible
 del GetModule
-import accessible
-from utils import *
-from constants import *
-import registry
+from . import accessible
+from .utils import *
+from .constants import *
+from . import registry
 
 # Create singleton registry.
 Registry = registry.Registry()

--- a/pyia2/accessible.py
+++ b/pyia2/accessible.py
@@ -25,8 +25,9 @@ Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.
 '''
 
-import new
 import types
+
+import six
 
 from comtypes.client import GetModule
 IAccessible2 = GetModule('ia2.tlb')
@@ -36,7 +37,7 @@ from ctypes import c_long, oledll, byref, create_unicode_buffer
 from comtypes.gen.Accessibility   import IAccessible
 from comtypes.gen.IAccessible2Lib import IAccessible2
 from comtypes import named_property, COMError, hresult
-from constants import CHILDID_SELF, \
+from .constants import CHILDID_SELF, \
     UNLOCALIZED_ROLE_NAMES, \
     UNLOCALIZED_STATE_NAMES
 
@@ -52,7 +53,7 @@ def _makeExceptionHandler(func):
     def _inner(self, *args, **kwargs):
         try:
             return func(self, *args, **kwargs)
-        except COMError, e:
+        except COMError as e:
             # TODO: Translate COMErrors to more pythonic equivalents.
             raise
     return _inner
@@ -73,7 +74,7 @@ def _mixExceptions(cls):
         if name.startswith('_'):
             continue
         # check if we're on a method
-        elif isinstance(obj, new.instancemethod):
+        elif isinstance(obj, types.MethodType):
             # wrap the function in an exception handler
             method = _makeExceptionHandler(obj)
             # add the wrapped function to the class
@@ -121,8 +122,13 @@ def _mixClass(cls, new_cls, ignore=[]):
             continue
         if isinstance(func, types.FunctionType):
             # build a new function that is a clone of the one from new_cls
-            method = new.function(func.func_code, func.func_globals, name, 
-                                  func.func_defaults, func.func_closure)
+            if six.PY2:
+                method = types.FunctionType(func.func_code, func.func_globals, name,
+                                            func.func_defaults, func.func_closure)
+            else:
+                method = types.FunctionType(func.__code__, func.__globals__, name,
+                                            func.__defaults__, func.__closure__)
+
             try:
                 # check if a method of the same name already exists in the 
                 # target
@@ -186,7 +192,7 @@ class _IAccessibleMixin(object):
                                              rgvarChildren, byref(pcObtained))
         except:
             pcObtained = c_long(0)
-        for i in xrange(pcObtained.value):
+        for i in range(pcObtained.value):
             child = rgvarChildren[i]
             if child.vt == VT_I4:
                 yield ManagedChildAccessible(self, child.value)
@@ -207,7 +213,7 @@ class _IAccessibleMixin(object):
     def accStateSet(self, child_id=CHILDID_SELF):
         states = []
         state = self.accState(child_id)
-        for shift in xrange(64):
+        for shift in range(64):
             state_bit = 1 << shift
             if state_bit & state:
                 states.append(
@@ -218,7 +224,7 @@ class _IAccessibleMixin(object):
     def accLocalizedStateSet(self, child_id=CHILDID_SELF):
         states = []
         state = self.accState(child_id)
-        for shift in xrange(64):
+        for shift in range(64):
             state_bit = 1 << shift
             if state_bit & state:
                 states.append(self._getStateText(state_bit & state))
@@ -288,7 +294,10 @@ class ManagedChildAccessible(object):
 
     def __nonzero__(self):
         return True
-    
+
+    def __bool__(self):
+        return True
+
     def __str__(self):
         try:
             return u'[%s | %s]' % (self.accRoleName(), 

--- a/pyia2/comtypesClient.py
+++ b/pyia2/comtypesClient.py
@@ -15,7 +15,7 @@
 
 # comtypes.client
 
-import sys, os, new
+import sys, os, types
 import ctypes
 
 import comtypes
@@ -41,7 +41,7 @@ def _find_gen_dir():
         try:
             from comtypes import gen
         except ImportError:
-            module = sys.modules["comtypes.gen"] = new.module("comtypes.gen")
+            module = sys.modules["comtypes.gen"] = types.ModuleType("comtypes.gen")
             comtypes.gen = module
         return None
     # determine the place where generated modules live
@@ -97,7 +97,7 @@ def GetBestInterface(punk):
         else:
             if ta.cImplTypes != 1:
                 # Hm, should we use dynamic now?
-                raise TypeError, "No default interface found"
+                raise TypeError("No default interface found")
             # Only one interface implemented, use that (even if
             # not marked as default).
             index = 0
@@ -120,7 +120,7 @@ def GetBestInterface(punk):
     logger.info("Default interface is %s", typeattr.guid)
     try:
         punk.QueryInterface(comtypes.IUnknown, typeattr.guid)
-    except comtypes.COMError, details:
+    except comtypes.COMError as details:
         logger.info("Does not implement default interface, returning dynamic object")
         return comtypes.client.dynamic.Dispatch(punk)
 

--- a/pyia2/constants.py
+++ b/pyia2/constants.py
@@ -423,6 +423,6 @@ IA2_EVENT_VISIBLE_DATA_CHANGED          = 0x122
 
 winEventIDsToEventNames={}
 
-for _sym, _val in locals().items():
+for _sym, _val in list(locals().items()):
     if _sym.startswith('EVENT_') or  _sym.startswith('IA2_EVENT_'):
         winEventIDsToEventNames[_val] = _sym

--- a/pyia2/event.py
+++ b/pyia2/event.py
@@ -24,8 +24,8 @@ Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.
 '''
 
-from constants import winEventIDsToEventNames
-from utils import accessibleObjectFromEvent
+from .constants import winEventIDsToEventNames
+from .utils import accessibleObjectFromEvent
 
 class Event(object):
     def __init__(self, 

--- a/pyia2/registry.py
+++ b/pyia2/registry.py
@@ -25,12 +25,12 @@ Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.
 '''
 
-import constants
+from . import constants
 import traceback
 from ctypes import CFUNCTYPE, c_int, c_voidp, windll
 from comtypes.client import PumpEvents
-from event import Event
-from utils import accessibleObjectFromEvent
+from .event import Event
+from .utils import accessibleObjectFromEvent
 
 class Registry(object):
     def __init__(self):
@@ -55,7 +55,7 @@ class Registry(object):
             
     def registerEventListener(self, client, *event_types):
         for event_type in event_types:
-            if self.clients.has_key((client, event_type)):
+            if (client, event_type) in self.clients:
                 continue
             hook_id = \
                 windll.user32.SetWinEventHook(
@@ -64,8 +64,8 @@ class Registry(object):
             if hook_id:
                 self.clients[(client, event_type)] = hook_id
             else:
-                print "Could not register callback for %s" % \
-                    constants.winEventIDsToEventNames.get(event_type, event_type)
+                print("Could not register callback for %s" % \
+                    constants.winEventIDsToEventNames.get(event_type, event_type))
 
     def deregisterEventListener(self, client, *event_types):
         for event_type in event_types:

--- a/pyia2/utils.py
+++ b/pyia2/utils.py
@@ -24,15 +24,17 @@ Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.
 '''
 
-import constants
+from . import constants
 from ctypes import windll, oledll, POINTER, byref, c_int
 from comtypes.automation import VARIANT
 from comtypes.gen.Accessibility import IAccessible
 from comtypes import COMError, IServiceProvider
 from comtypes.client import GetModule, CreateObject
-import comtypesClient
+from . import comtypesClient
 
-from constants import CHILDID_SELF, \
+from six import text_type
+
+from .constants import CHILDID_SELF, \
     UNLOCALIZED_ROLE_NAMES, \
     UNLOCALIZED_STATE_NAMES, \
     UNLOCALIZED_IA2_STATE_NAMES
@@ -131,7 +133,7 @@ def accessibleTableCellFromAccessible(pacc, child_id):
                 return pacc2
 
         except Exception as e:
-            print "ERROR cannot get IA2 Table Cell object:", str(e)
+            print("ERROR cannot get IA2 Table Cell object: %s" % e)
 
     return None
 
@@ -165,7 +167,7 @@ def accessibleRelationFromAccessible2(pacc2):
             out +=  "  Number(" + str(pacc2.nRelations) + ")\n\r "
 
         except Exception as e:
-            print "ERROR cannot get IA2 nRelation:", str(e)
+            print("ERROR cannot get IA2 nRelation: %s" % e)
 
         try:
             for i in range (pacc2.nRelations):
@@ -183,7 +185,7 @@ def accessibleRelationFromAccessible2(pacc2):
             return out
 
         except Exception as e:
-            print "ERROR cannot get IA2 relation:", str(e)
+            print("ERROR cannot get IA2 relation: %s" % e)
 
     return "None"    
 
@@ -322,7 +324,7 @@ def findAncestor(acc, pred):
         acc = parent
 
 def printSubtree(acc, indent=0):
-  print '%s%s' % (indent*' ', unicode(acc).encode('cp1252', 'ignore'))
+  print('%s%s' % (indent*' ', text_type(acc).encode('cp1252', 'ignore')))
   for child in acc:
     try:
       printSubtree(child, indent+1)

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(name="pyia2",
       version=pyia2.__version__,
       packages=["pyia2"],
       package_data={"": ["*.tlb"]},
-      install_requires=["comtypes"],
+      install_requires=["comtypes", "six"],
       cmdclass={
           'develop': PostDevelopCommand,
           'install': PostInstallCommand,

--- a/test-callback.py
+++ b/test-callback.py
@@ -130,7 +130,7 @@ def event_cb(event):
             print("IA2 ISSELECTED: undefined")
 
     else:
-        print "Not IA2 Object"
+        print("Not IA2 Object")
 
 
 print("This program monitors document and focus changes events for MSAA and IAccessible2 and provides information about the event.")

--- a/test.py
+++ b/test.py
@@ -1,14 +1,19 @@
-import pyia2
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+
+import six
+
+import pyia2
+
+if six.PY2:
+  reload(sys)
+  sys.setdefaultencoding('utf-8')
 
 desktop = pyia2.getDesktop()
-print str(desktop)
+print(str(desktop))
 
 for window in desktop:
   if not window.accState(0) & pyia2.STATE_SYSTEM_INVISIBLE:
-     print repr(str(window))
+     print(repr(str(window)))
 
 # Need to get ia2.tlb
 # create a module comptypes.client.GetModule(path to ia2.tlb)


### PR DESCRIPTION
I have gotten `pyia2` working with Python 3, while still keeping it working with Python 2.7. I've added the [`six` package](https://pypi.org/project/six/) as a dependency in `setup.py`.

CC @wolfmanstout

### Testing

I have tested my changes mostly by using Dragonfly's integration with `pyia2` (see [this blog post](http://handsfreecoding.org/2018/12/27/enhanced-text-manipulation-using-accessibility-apis/)). The IAccessible2-enabled application I tested with was Mozilla Firefox. `pyia2`'s test scripts also work correctly using either major Python version.

### `PumpEvents()` errors

One other thing I've done is suppressed Windows error messages raised from the `PumpEvents` comtypes function. For example:
```
[WinError -2147417835] OLE has sent a request and is waiting for a reply
```

These errors are only present on Python 3.x and seem to have no impact on `pyia2`'s functionality. I've logged them as debug messages because they're pretty spammy.

### 64-bit trouble?

I noticed in my testing that the accessibility integration doesn't work on 64-bit versions of Python, or at least it doesn't work with Firefox. I'm guessing this is something to do with `comtypes`, the `IAccessible2Proxy` DLL or Dragonfly's `pyia2` integration.